### PR TITLE
Add ID test method for intervention queries

### DIFF
--- a/causal_reasoning/causal_model.py
+++ b/causal_reasoning/causal_model.py
@@ -155,7 +155,8 @@ class CausalModel:
             bds_zy = infer.get_all_backdoor_adjustment_sets(X=z, Y=Y)
             if any(not Bd.isdisjoint(latent_labels) for Bd in bds_zy):
                 continue
-            if all(X in path[1:-1] for path in all_directed_paths(G, z, Y)):
+            paths = list(all_directed_paths(G, z, Y))
+            if paths and all(X in path[1:-1] for path in paths):
                 return True, "iv", z
 
         data_obs = self.data.drop(

--- a/causal_reasoning/causal_model.py
+++ b/causal_reasoning/causal_model.py
@@ -121,6 +121,8 @@ class CausalModel:
         if target_node is not None:
             self.target = target_node
 
+        if not self.interventions:
+            raise Exception("Expect interventions to be a non-empty list")
         X = self.interventions[0].label
         Y = self.target.label
         latent_labels = {u.label for u in (self.unobservables or [])}

--- a/causal_reasoning/causal_model.py
+++ b/causal_reasoning/causal_model.py
@@ -1,5 +1,6 @@
 import copy
 import logging
+import warnings
 from typing import TypeVar
 
 import networkx as nx
@@ -7,11 +8,13 @@ from pandas import DataFrame
 from pgmpy.models import DiscreteBayesianNetwork
 from pgmpy.inference.CausalInference import CausalInference
 from pgmpy.estimators import MaximumLikelihoodEstimator
+from dowhy import CausalModel as DowhyCausalModel
 
 from causal_reasoning.utils.graph_plotter import plot_graph_image
 
 logger = logging.getLogger(__name__)
 logging.getLogger("pgmpy").setLevel(logging.WARNING)
+logging.getLogger("dowhy.causal_model").setLevel(logging.ERROR)
 
 from causal_reasoning.do_calculus_algorithm.linear_programming.opt_problem_builder import (
     build_bi_linear_problem,
@@ -98,6 +101,92 @@ class CausalModel:
             y=set(set_nodes_Y),
             z=set(set_nodes_Z),
         )
+    
+    def is_identifiable_intervention(
+        self, interventions: list[tuple[str, int]] = [], target: tuple[str, int] = None
+    ) -> bool:
+        """
+        Check if the intervention is identifiable.
+        """
+        interventions_nodes = convert_tuples_list_into_nodes_list(interventions, self.graph)
+        if interventions_nodes is None and self.interventions is None:
+            raise Exception("Expect intervention to be not None")
+
+        if interventions_nodes is not None:
+            self.interventions = interventions_nodes
+
+        target_node = convert_tuple_into_node(target, self.graph)
+        if target_node is None and self.target is None:
+            raise Exception("Expect target to be not None")
+        if target_node is not None:
+            self.target = target_node
+
+        X = self.interventions[0].label
+        Y = self.target.label
+        latent_labels = {u.label for u in (self.unobservables or [])}
+
+        dbn = DiscreteBayesianNetwork()
+        dbn.add_edges_from(self.graph.DAG.edges())
+
+        infer = CausalInference(dbn)
+
+        backdoors = infer.get_all_backdoor_adjustment_sets(X=X, Y=Y)
+        obs_bds = [Z for Z in backdoors if Z.isdisjoint(latent_labels)]
+        if obs_bds:
+            Z = min(obs_bds, key=len)
+            return True, "backdoor", Z
+        
+        frontdoors = infer.get_all_frontdoor_adjustment_sets(X=X, Y=Y)
+        obs_fds = [Z for Z in frontdoors if Z.isdisjoint(latent_labels)]
+        if obs_fds:
+            W = min(obs_fds, key=len)
+            return True, "frontdoor", W
+
+        def all_directed_paths(G, src, dst):
+            for path in nx.all_simple_paths(G, src, dst):
+                if all(G.has_edge(u, v) for u, v in zip(path, path[1:])):
+                    yield path
+
+        G = self.graph.DAG
+        observed = set(G.nodes()) - latent_labels
+        for z in observed - {X, Y}:
+            if not G.has_edge(z, X):
+                continue
+            bds_zy = infer.get_all_backdoor_adjustment_sets(X=z, Y=Y)
+            if any(not Bd.isdisjoint(latent_labels) for Bd in bds_zy):
+                continue
+            if all(X in path[1:-1] for path in all_directed_paths(G, z, Y)):
+                return True, "iv", z
+
+        data_obs = self.data.drop(
+            columns=[u for u in latent_labels if u in self.data.columns]
+        )
+
+        for U in (self.unobservables or []):
+            if nx.has_path(G, U.label, X) and nx.has_path(G, U.label, Y):
+                return False, None, None
+            
+        G_do = G.copy()
+        G_do.remove_edges_from(list(G_do.in_edges(X)))
+        if nx.is_d_separator(G_do, {X}, {Y}, set()):
+            return True, "graphical", None
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            dowhy_model = DowhyCausalModel(
+                data=data_obs,
+                graph=self.graph.DAG,
+                treatment=X,
+                outcome=Y
+            )
+            try:
+                estimand = dowhy_model.identify_effect(
+                    method_name="id-algorithm",
+                    proceed_when_unidentifiable=False
+                )
+                return True, "id-algorithm", estimand
+            except Exception:
+                return False, None, None
 
     def identifiable_intervention_query(
         self, interventions: list[tuple[str, int]] = [], target: tuple[str, int] = None

--- a/causal_reasoning/causal_model.py
+++ b/causal_reasoning/causal_model.py
@@ -104,7 +104,7 @@ class CausalModel:
     
     def is_identifiable_intervention(
         self, interventions: list[tuple[str, int]] = [], target: tuple[str, int] = None
-    ) -> bool:
+    ) -> tuple[bool, str | None, Any | None]:
         """
         Check if the intervention is identifiable.
         """


### PR DESCRIPTION
- Added a method to the CausalModel class that checks if a given intervention query is identifiable or not and informs by which methods it is identifiable. The function performs backdoor, frontdoor, IV, ID algorithm and other graphical checks to find possible identification configurations.
- Added unit tests to the ID test method